### PR TITLE
Interfaith wheel, Publications hub, About mission, h1 normalization

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#fbfaf6" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <!-- Per-page <title>, meta description, OG, and Twitter card tags are
          injected at build time by src/components/PageHead.tsx (Helmet via
          vite-react-ssg's <Head>). Leave the head free of static defaults

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <radialGradient id="fbg" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#2c1c06"/>
+      <stop offset="100%" stop-color="#0e0902"/>
+    </radialGradient>
+  </defs>
+  <!-- Background -->
+  <circle cx="32" cy="32" r="32" fill="url(#fbg)"/>
+  <!-- Outer ring -->
+  <circle cx="32" cy="32" r="30.5" fill="none" stroke="#c9a240" stroke-width="1.5"/>
+  <!-- Inner ring -->
+  <circle cx="32" cy="32" r="10" fill="none" stroke="#c9a240" stroke-width="0.8" opacity="0.7"/>
+  <!-- 8 spokes -->
+  <g stroke="#c9a240" stroke-width="0.5" opacity="0.3">
+    <line x1="32" y1="22" x2="32" y2="12" transform="rotate(0,32,32)"/>
+    <line x1="32" y1="22" x2="32" y2="12" transform="rotate(45,32,32)"/>
+    <line x1="32" y1="22" x2="32" y2="12" transform="rotate(90,32,32)"/>
+    <line x1="32" y1="22" x2="32" y2="12" transform="rotate(135,32,32)"/>
+    <line x1="32" y1="22" x2="32" y2="12" transform="rotate(180,32,32)"/>
+    <line x1="32" y1="22" x2="32" y2="12" transform="rotate(225,32,32)"/>
+    <line x1="32" y1="22" x2="32" y2="12" transform="rotate(270,32,32)"/>
+    <line x1="32" y1="22" x2="32" y2="12" transform="rotate(315,32,32)"/>
+  </g>
+  <!-- Center sunburst -->
+  <g transform="translate(32,32)" fill="#c9a240">
+    <rect x="-0.8" y="-8" width="1.6" height="5" rx="0.8"/>
+    <rect x="-0.8" y="-8" width="1.6" height="5" rx="0.8" transform="rotate(45)"/>
+    <rect x="-0.8" y="-8" width="1.6" height="5" rx="0.8" transform="rotate(90)"/>
+    <rect x="-0.8" y="-8" width="1.6" height="5" rx="0.8" transform="rotate(135)"/>
+    <rect x="-0.8" y="-8" width="1.6" height="5" rx="0.8" transform="rotate(180)"/>
+    <rect x="-0.8" y="-8" width="1.6" height="5" rx="0.8" transform="rotate(225)"/>
+    <rect x="-0.8" y="-8" width="1.6" height="5" rx="0.8" transform="rotate(270)"/>
+    <rect x="-0.8" y="-8" width="1.6" height="5" rx="0.8" transform="rotate(315)"/>
+    <circle r="2.5" fill="#c9a240"/>
+    <circle r="1.4" fill="#ffe090" opacity="0.9"/>
+  </g>
+  <!-- 8 symbols at r=19 — tiny but visible at 64px, reads as textured ring at 16px -->
+  <g font-size="7" fill="#c9a240" text-anchor="middle" dominant-baseline="central"
+     font-family="'Segoe UI Symbol','Apple Symbols','Noto Sans Symbols',sans-serif">
+    <text x="32"  y="13">✝</text>
+    <text x="45.4" y="18.6">✡</text>
+    <text x="51"  y="32">☪</text>
+    <text x="45.4" y="45.4">ॐ</text>
+    <text x="32"  y="51">☸</text>
+    <text x="18.6" y="45.4">☬</text>
+    <text x="13"  y="32">☯</text>
+    <text x="18.6" y="18.6">✴</text>
+  </g>
+</svg>

--- a/public/images/interfaith-wheel.svg
+++ b/public/images/interfaith-wheel.svg
@@ -1,0 +1,135 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"
+     role="img" aria-label="Wheel of World Religions — interfaith mandala">
+  <title>Wheel of World Religions</title>
+
+  <defs>
+    <radialGradient id="bg" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#2c1c06"/>
+      <stop offset="100%" stop-color="#0e0902"/>
+    </radialGradient>
+    <radialGradient id="centerGlow" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#ffe090" stop-opacity="1"/>
+      <stop offset="60%" stop-color="#c9a240" stop-opacity="0.6"/>
+      <stop offset="100%" stop-color="#c9a240" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="glow" x="-30%" y="-30%" width="160%" height="160%">
+      <feGaussianBlur stdDeviation="5" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+    <filter id="softglow" x="-20%" y="-20%" width="140%" height="140%">
+      <feGaussianBlur stdDeviation="2.5" result="blur"/>
+      <feMerge>
+        <feMergeNode in="blur"/>
+        <feMergeNode in="SourceGraphic"/>
+      </feMerge>
+    </filter>
+  </defs>
+
+  <!-- Background -->
+  <circle cx="256" cy="256" r="256" fill="url(#bg)"/>
+
+  <!-- Outer decorative rings -->
+  <circle cx="256" cy="256" r="248" fill="none" stroke="#c9a240" stroke-width="2.5"/>
+  <circle cx="256" cy="256" r="240" fill="none" stroke="#c9a240" stroke-width="0.6"
+          stroke-dasharray="5 5" opacity="0.4"/>
+
+  <!-- Subtle spoke lines from inner circle to symbol positions -->
+  <g stroke="#c9a240" stroke-width="0.6" opacity="0.25">
+    <!-- 8 spokes at r=78 to r=132 -->
+    <line x1="256" y1="178" x2="256" y2="124"/>
+    <line x1="311" y1="201" x2="367" y2="157" transform="rotate(0,256,256)"/>
+    <!-- Using rotate transform for all 8 spokes -->
+    <line x1="256" y1="178" x2="256" y2="124" transform="rotate(45,256,256)"/>
+    <line x1="256" y1="178" x2="256" y2="124" transform="rotate(90,256,256)"/>
+    <line x1="256" y1="178" x2="256" y2="124" transform="rotate(135,256,256)"/>
+    <line x1="256" y1="178" x2="256" y2="124" transform="rotate(180,256,256)"/>
+    <line x1="256" y1="178" x2="256" y2="124" transform="rotate(225,256,256)"/>
+    <line x1="256" y1="178" x2="256" y2="124" transform="rotate(270,256,256)"/>
+    <line x1="256" y1="178" x2="256" y2="124" transform="rotate(315,256,256)"/>
+  </g>
+
+  <!-- Inner circle -->
+  <circle cx="256" cy="256" r="77" fill="none" stroke="#c9a240" stroke-width="1.5" opacity="0.7"/>
+
+  <!-- Center glow wash -->
+  <circle cx="256" cy="256" r="65" fill="url(#centerGlow)" opacity="0.5"/>
+
+  <!-- Center sunburst — 8 rays -->
+  <g transform="translate(256,256)" filter="url(#glow)">
+    <g fill="#c9a240" opacity="0.9">
+      <rect x="-1.8" y="-62" width="3.6" height="36" rx="1.8"/>
+      <rect x="-1.8" y="-62" width="3.6" height="36" rx="1.8" transform="rotate(45)"/>
+      <rect x="-1.8" y="-62" width="3.6" height="36" rx="1.8" transform="rotate(90)"/>
+      <rect x="-1.8" y="-62" width="3.6" height="36" rx="1.8" transform="rotate(135)"/>
+      <rect x="-1.8" y="-62" width="3.6" height="36" rx="1.8" transform="rotate(180)"/>
+      <rect x="-1.8" y="-62" width="3.6" height="36" rx="1.8" transform="rotate(225)"/>
+      <rect x="-1.8" y="-62" width="3.6" height="36" rx="1.8" transform="rotate(270)"/>
+      <rect x="-1.8" y="-62" width="3.6" height="36" rx="1.8" transform="rotate(315)"/>
+    </g>
+    <!-- Center dot -->
+    <circle r="10" fill="#c9a240"/>
+    <circle r="6"  fill="#ffe090" opacity="0.9"/>
+  </g>
+
+  <!-- ═══ Religious Symbols at r=155 from center ═══ -->
+  <!--
+    Positions (r=155):
+      0°  top          → (256, 101)   Christian Cross
+      45° top-right    → (366, 146)   Star of David
+      90° right        → (411, 256)   Crescent & Star
+      135° bottom-right → (366, 366)  Om / Hinduism
+      180° bottom      → (256, 411)   Dharma Wheel / Buddhism
+      225° bottom-left  → (146, 366)  Khanda / Sikhism
+      270° left        → (101, 256)   Yin-Yang / Taoism
+      315° top-left    → (146, 146)   Eight-pointed star / Bahá'í
+  -->
+  <g font-size="52" fill="#c9a240" text-anchor="middle" dominant-baseline="central"
+     filter="url(#softglow)"
+     font-family="'Segoe UI Symbol','Apple Symbols','Noto Sans Symbols','Symbola',sans-serif">
+
+    <!-- Christianity: Latin Cross ✝ -->
+    <text x="256" y="104">✝</text>
+
+    <!-- Judaism: Star of David ✡ -->
+    <text x="366" y="149">✡</text>
+
+    <!-- Islam: Star and Crescent ☪ -->
+    <text x="408" y="256">☪</text>
+
+    <!-- Hinduism: Om ॐ -->
+    <text x="366" y="366"
+          font-family="'Noto Sans Devanagari','Devanagari MT','Arial Unicode MS',serif"
+          font-size="46">ॐ</text>
+
+    <!-- Buddhism: Dharma Wheel ☸ -->
+    <text x="256" y="410">☸</text>
+
+    <!-- Sikhism: Khanda ☬ -->
+    <text x="146" y="366">☬</text>
+
+    <!-- Taoism / Zen: Yin-Yang ☯ -->
+    <text x="104" y="256">☯</text>
+
+    <!-- Bahá'í / Universal: Eight-pointed star ✴ -->
+    <text x="146" y="149">✴</text>
+
+  </g>
+
+  <!-- Tradition labels — tiny, readable at full size, graceful at icon size -->
+  <g font-size="9.5" fill="#c9a240" text-anchor="middle" dominant-baseline="central"
+     opacity="0.5" letter-spacing="0.8"
+     font-family="'Georgia','Times New Roman',serif">
+    <text x="256" y="57">CHRISTIANITY</text>
+    <text x="390" y="104" transform="rotate(45,390,104)">JUDAISM</text>
+    <text x="455" y="256" transform="rotate(90,455,256)">ISLAM</text>
+    <text x="390" y="408" transform="rotate(135,390,408)">HINDUISM</text>
+    <text x="256" y="457">BUDDHISM</text>
+    <text x="122" y="408" transform="rotate(-135,122,408)">SIKHISM</text>
+    <text x="57"  y="256" transform="rotate(-90,57,256)">TAOISM</text>
+    <text x="122" y="104" transform="rotate(-45,122,104)">BAHÁ'Í</text>
+  </g>
+
+</svg>

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -21,7 +21,7 @@ export default function About() {
       <p className="text-sm uppercase tracking-widest text-accent mb-4">
         Hope &amp; Truth Ministry
       </p>
-      <h1 className="font-serif text-5xl mb-8 leading-tight">
+      <h1 className="font-serif text-4xl mb-8 leading-tight">
         A ministry without walls.
       </h1>
 
@@ -148,12 +148,12 @@ export default function About() {
         </li>
       </ul>
 
-      <h2 className="font-serif text-2xl mt-16 mb-4">Find your way in</h2>
+      <h2 className="font-serif text-2xl mt-16 mb-4">What happens here</h2>
       <div className="space-y-4 text-ink/80 max-w-prose leading-relaxed">
         <p>
           Start wherever you are. The{" "}
-          <a className="text-accent underline" href="/sermons">sermons</a>{" "}
-          follow the rhythm of the{" "}
+          <a className="text-accent underline" href="/sermons">sermons and reflections</a>{" "}
+          follow the cadence of the{" "}
           <a
             href={VANDERBILT_RCL}
             target="_blank"
@@ -162,16 +162,16 @@ export default function About() {
           >
             Revised Common Lectionary
           </a>{" "}
-          &mdash; new writing arrives most weeks. The{" "}
+          &mdash; new writing arrives most weeks. These along with the{" "}
           <a className="text-accent underline" href="/meditations">
             meditations
           </a>{" "}
-          are there for those who want to be still. The{" "}
+          are there for contemplation and exploring the heart. The{" "}
           <a className="text-accent underline" href="/publications">
             Publications hub
           </a>{" "}
-          gathers inspiration, resources, and work ideation for those called
-          to build something. And the{" "}
+          helps to gather inspiration, resources, and work ideation for those called
+          to build with purpose. The{" "}
           <a className="text-accent underline" href="/contact">
             contact page
           </a>{" "}

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -67,15 +67,15 @@ export default function About() {
         </p>
         <p>
           Beyond the congregation, this ministry serves as a resource for
-          anyone called to build &mdash; a church, a nonprofit, a
+          anyone called to build &mdash; a church, a nonprofit, or a
           mission-driven organization of any kind. The resources here are
-          offered freely: inspiration to fuel the vision, tools to sustain
+          offered to help inspire the vision with tools to sustain
           the work, and guidance for those just beginning to plant something
           new.
         </p>
       </div>
 
-      <h2 className="font-serif text-2xl mt-16 mb-4">What we&apos;re for</h2>
+      <h2 className="font-serif text-2xl mt-16 mb-4">Our guiding posts</h2>
       <ul className="space-y-3 text-ink/80 max-w-prose leading-relaxed list-disc pl-6">
         <li>Growing in love of the Holy Presence and of all our neighbors.</li>
         <li>
@@ -107,7 +107,7 @@ export default function About() {
           and area food pantries.
         </li>
         <li>
-          Volunteering with broader voices for progressive theology and
+          Connecting with broader voices for
           interfaith cooperation, including{" "}
           <a
             className="text-accent underline"
@@ -148,10 +148,12 @@ export default function About() {
         </li>
       </ul>
 
-      <h2 className="font-serif text-2xl mt-16 mb-4">How this ministry works</h2>
+      <h2 className="font-serif text-2xl mt-16 mb-4">Find your way in</h2>
       <div className="space-y-4 text-ink/80 max-w-prose leading-relaxed">
         <p>
-          Sermons and reflections are posted in keeping with the{" "}
+          Start wherever you are. The{" "}
+          <a className="text-accent underline" href="/sermons">sermons</a>{" "}
+          follow the rhythm of the{" "}
           <a
             href={VANDERBILT_RCL}
             target="_blank"
@@ -159,34 +161,28 @@ export default function About() {
             className="text-accent underline underline-offset-2 hover:no-underline"
           >
             Revised Common Lectionary
-          </a>
-          , the three-year cycle that mainline Protestant congregations use to
-          read through the Scriptures together. A new piece typically arrives
-          weekly.
-        </p>
-        <p>
-          The{" "}
+          </a>{" "}
+          &mdash; new writing arrives most weeks. The{" "}
+          <a className="text-accent underline" href="/meditations">
+            meditations
+          </a>{" "}
+          are there for those who want to be still. The{" "}
           <a className="text-accent underline" href="/publications">
             Publications hub
           </a>{" "}
-          gathers everything in one place &mdash; inspiration, practical
-          resources, and work ideation for those called to build. Browse the{" "}
-          <a className="text-accent underline" href="/sermons">sermons</a>,
-          sit with the{" "}
-          <a className="text-accent underline" href="/meditations">
-            meditations
-          </a>
-          , or{" "}
+          gathers inspiration, resources, and work ideation for those called
+          to build something. And the{" "}
           <a className="text-accent underline" href="/contact">
-            get in touch
+            contact page
           </a>{" "}
-          with a question, a prayer request, or an idea you&apos;re ready to explore.
+          is always open &mdash; for a question, a prayer request, or an
+          idea you are ready to explore.
         </p>
       </div>
 
       <div className="mt-16 pt-8 border-t border-ink/10">
         <p className="font-serif text-2xl text-ink/80">
-          Peace be with you.
+          <i>Jesus came and stood among them and said, "Peace be with you." (John 20:19b)</i>
         </p>
       </div>
     </div>

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -15,7 +15,7 @@ export default function About() {
     <div className="max-w-3xl mx-auto px-6 py-16">
       <PageHead
         title="About"
-        description="Hope and Truth Ministry is a ministry without walls — open and affirming, for the wandering, the doubting, the questioning, the hurting, and the hopeful. Wherever you are on the journey, there is space for you."
+        description="Hope and Truth Ministry is a spiritual home and a launchpad — a place to find inspiration, gather practical resources, and discover how to build your own ministry or nonprofit organization."
         path="/about/"
       />
       <p className="text-sm uppercase tracking-widest text-accent mb-4">
@@ -27,16 +27,17 @@ export default function About() {
 
       <div className="space-y-6 text-lg text-ink/80 max-w-prose leading-relaxed">
         <p>
-          Are you in a wilderness? Looking for a path? You are welcome here.
+          Hope and Truth Ministry is a spiritual home and a launchpad. A place
+          to find inspiration, gather practical resources, and discover how to
+          build something of your own &mdash; a congregation, a nonprofit, an
+          organization rooted in your calling.
         </p>
         <p>
-          Hope and Truth Ministry is an interfaith outreach to anyone looking for
-          &mdash; an honest, welcoming, open and affirming ministry. For
-          the wandering, the doubting, the questioning, the hurting, and the
+          It is open and affirming, interfaith and without walls. For the
+          wandering, the doubting, the questioning, the hurting, and the
           hopeful. For those whose church is online. For those finding their
-          way back. For those still seeking. For those who want to think
-          faithfully alongside others. Wherever you are on the journey, there
-          is for you here.
+          way back. For those still seeking. And for those who are ready to
+          begin building.
         </p>
       </div>
 
@@ -54,6 +55,23 @@ export default function About() {
           Creator through different paths, that leaves judgment to the One
           who made us, and that takes seriously the call to love our
           neighbors &mdash; as ourselves.
+        </p>
+      </div>
+
+      <h2 className="font-serif text-2xl mt-16 mb-4">The mission</h2>
+      <div className="space-y-4 text-ink/80 max-w-prose leading-relaxed">
+        <p>
+          Hope and Truth Ministry exists to provide a truly welcoming,
+          open and affirming community to all people seeking meaning, purpose,
+          and connection &mdash; no matter where they are on life&apos;s journey.
+        </p>
+        <p>
+          Beyond the congregation, this ministry serves as a resource for
+          anyone called to build &mdash; a church, a nonprofit, a
+          mission-driven organization of any kind. The resources here are
+          offered freely: inspiration to fuel the vision, tools to sustain
+          the work, and guidance for those just beginning to plant something
+          new.
         </p>
       </div>
 
@@ -147,17 +165,22 @@ export default function About() {
           weekly.
         </p>
         <p>
-          Browse the{" "}
+          The{" "}
+          <a className="text-accent underline" href="/publications">
+            Publications hub
+          </a>{" "}
+          gathers everything in one place &mdash; inspiration, practical
+          resources, and work ideation for those called to build. Browse the{" "}
           <a className="text-accent underline" href="/sermons">sermons</a>,
-          drop in on{" "}
-          <a className="text-accent underline" href="/worship-resources">
-            worship resources
+          sit with the{" "}
+          <a className="text-accent underline" href="/meditations">
+            meditations
           </a>
           , or{" "}
           <a className="text-accent underline" href="/contact">
             get in touch
           </a>{" "}
-          to get new reflections in your inbox.
+          with a question, a prayer request, or an idea you&apos;re ready to explore.
         </p>
       </div>
 

--- a/src/pages/Care.tsx
+++ b/src/pages/Care.tsx
@@ -71,7 +71,7 @@ export default function Care() {
       <p className="text-sm uppercase tracking-widest text-accent mb-4">
         Care &amp; Support
       </p>
-      <h1 className="font-serif text-5xl mb-8 leading-tight">
+      <h1 className="font-serif text-4xl mb-8 leading-tight">
         You are not alone.
       </h1>
 

--- a/src/pages/Give.tsx
+++ b/src/pages/Give.tsx
@@ -26,7 +26,7 @@ export default function Give() {
       <p className="text-sm uppercase tracking-widest text-accent mb-4">
         Give &amp; Volunteer
       </p>
-      <h1 className="font-serif text-5xl mb-8 leading-tight">
+      <h1 className="font-serif text-4xl mb-8 leading-tight">
         Help keep the lamp lit.
       </h1>
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -30,9 +30,18 @@ export default function Home() {
           <p className="text-sm uppercase tracking-widest text-accent mb-4">
             Hope &amp; Truth Ministry
           </p>
-          <h1 className="font-serif text-5xl sm:text-6xl leading-tight mb-6">
+          <h1 className="font-serif text-5xl sm:text-6xl leading-tight mb-8">
             A ministry without walls.
           </h1>
+
+          <div className="flex justify-center mb-8">
+            <img
+              src="/images/interfaith-wheel.svg"
+              alt="Interfaith mandala — symbols of Christianity, Judaism, Islam, Hinduism, Buddhism, Sikhism, Taoism, and Bahá'í arranged in a circle of unity"
+              className="w-52 h-52 sm:w-64 sm:h-64"
+            />
+          </div>
+
           <p className="text-xl text-ink/80 max-w-prose leading-relaxed mb-8">
             For the wandering, the doubting, the hurting, and the hopeful.
             For people without a congregation, and for people who have found

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -30,7 +30,7 @@ export default function Home() {
           <p className="text-sm uppercase tracking-widest text-accent mb-4">
             Hope &amp; Truth Ministry
           </p>
-          <h1 className="font-serif text-5xl sm:text-6xl leading-tight mb-8">
+          <h1 className="font-serif text-4xl sm:text-5xl leading-tight mb-8">
             A ministry without walls.
           </h1>
 

--- a/src/pages/Meditations.tsx
+++ b/src/pages/Meditations.tsx
@@ -37,8 +37,8 @@ export default function Meditations() {
       <p className="text-sm uppercase tracking-widest text-accent mb-4">
         Contemplative Practice
       </p>
-      <h1 className="font-serif text-5xl mb-6 leading-tight">
-        Be still, and know.
+      <h1 className="font-serif text-4xl mb-6 leading-tight">
+        Be still and rest your anxious mind
       </h1>
 
       <div className="space-y-5 text-lg text-ink/80 max-w-prose leading-relaxed">
@@ -55,7 +55,7 @@ export default function Meditations() {
       <section className="mt-14">
         <h2 className="font-serif text-2xl mb-4">Lectio Divina</h2>
         <p className="text-ink/80 max-w-prose leading-relaxed mb-6">
-          <em>Sacred reading</em> &mdash; an ancient Christian practice of
+          <em>Sacred reading</em> &mdash; a Christian practice of
           moving through a short scripture passage slowly, listening for what
           stirs rather than what instructs.
         </p>

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -9,7 +9,7 @@ export default function NotFound() {
         description="The page you're looking for doesn't exist on this site."
         path="/404/"
       />
-      <h1 className="font-serif text-5xl mb-4">Not found</h1>
+      <h1 className="font-serif text-4xl mb-4">Not found</h1>
       <p className="text-ink/70 mb-6">
         The page you&apos;re looking for doesn&apos;t exist on this site.
       </p>

--- a/src/pages/Ordination.tsx
+++ b/src/pages/Ordination.tsx
@@ -13,7 +13,7 @@ export default function Ordination() {
       <p className="text-sm uppercase tracking-widest text-accent mb-4">
         Ordination &amp; Ministry
       </p>
-      <h1 className="font-serif text-5xl mb-6 leading-tight">
+      <h1 className="font-serif text-4xl mb-6 leading-tight">
         Called to serve?
       </h1>
 

--- a/src/pages/Publications.tsx
+++ b/src/pages/Publications.tsx
@@ -1,98 +1,229 @@
 import { Link } from "react-router-dom";
 import PageHead from "~/components/PageHead";
 
+// ── Content model ─────────────────────────────────────────────────────────────
+
+const INSPIRATION = [
+  {
+    title: "Sermons",
+    desc: "Hundreds of sermons drawn from the Revised Common Lectionary — a year's worth of scripture, season by season.",
+    href: "/sermons",
+    live: true,
+    cta: "Browse the archive",
+  },
+  {
+    title: "Meditations & Contemplative Practice",
+    desc: "Lectio Divina, centering prayer, Zen and Taoist wisdom, Sufi insight — practices for the inner journey.",
+    href: "/meditations",
+    live: true,
+    cta: "Sit with the practices",
+  },
+  {
+    title: "Worship Resources",
+    desc: "Service orders, Lessons & Carols, pastoral prayers — materials that carry the season into the room.",
+    href: "/worship-resources",
+    live: true,
+    cta: "Browse resources",
+  },
+  {
+    title: "Newsletters",
+    desc: "Seasonal letters from this community — reflections, invitations, and notes from the road.",
+    href: null,
+    live: false,
+    cta: "Coming soon",
+  },
+];
+
+const RESOURCES = [
+  {
+    title: "Congregation Study Guides",
+    desc: "Devotional materials, liturgical planning tools, and small-group resources for congregations of any size.",
+    href: null,
+    live: false,
+  },
+  {
+    title: "Funding & Stewardship",
+    desc: "Guides for annual giving campaigns, capital initiatives, and building a healthy financial culture in your ministry — from transactions to transformation.",
+    href: "/give",
+    live: true,
+    cta: "See stewardship resources",
+  },
+  {
+    title: "Volunteer Development",
+    desc: "Frameworks for recruiting, training, and sustaining volunteers across seasons and leadership transitions.",
+    href: null,
+    live: false,
+  },
+  {
+    title: "Communications & Outreach",
+    desc: "How to reach people where they are — community presence, storytelling, and building the message that matches your mission.",
+    href: null,
+    live: false,
+  },
+];
+
+const IDEATION = [
+  {
+    title: "Seeding a Ministry or Nonprofit",
+    desc: "Step-by-step guidance for starting something new — incorporation, governance, first-year operations, and sustaining momentum past the founding season.",
+    href: null,
+    live: false,
+  },
+  {
+    title: "Organizational Development",
+    desc: "Moving from founding vision to durable structure — for congregations, nonprofits, and faith-based organizations at any stage of growth.",
+    href: null,
+    live: false,
+  },
+  {
+    title: "Purpose-Driven Strategy",
+    desc: "Aligning people, programs, budget, and communications around a clear calling. For any organization where the mission is the point.",
+    href: null,
+    live: false,
+  },
+  {
+    title: "Ordination & Ministry Formation",
+    desc: "Resources for those called to lead — formation, credentials, and the questions that come before the title.",
+    href: "/ordination",
+    live: true,
+    cta: "Explore ordination",
+  },
+];
+
+// ── Shared ───────────────────────────────────────────────────────────────────
+
+type Item = {
+  title: string;
+  desc: string;
+  href: string | null;
+  live: boolean;
+  cta?: string;
+};
+
+function TrackItems({ items }: { items: Item[] }) {
+  return (
+    <ul className="space-y-5">
+      {items.map((item) => (
+        <li key={item.title} className="flex items-start gap-3">
+          <div
+            className={`mt-1.5 w-1.5 h-1.5 rounded-full shrink-0 ${
+              item.live ? "bg-accent" : "bg-ink/20"
+            }`}
+          />
+          <div>
+            {item.live ? (
+              <Link
+                to={item.href!}
+                className="font-serif text-lg hover:text-accent transition-colors"
+              >
+                {item.title}
+              </Link>
+            ) : (
+              <span className="font-serif text-lg text-ink/55">{item.title}</span>
+            )}
+            <p className="text-sm text-ink/65 mt-0.5 leading-relaxed max-w-prose">
+              {item.desc}
+            </p>
+            {item.live ? (
+              <p className="text-xs text-accent mt-1 font-medium">{item.cta} &rarr;</p>
+            ) : (
+              <p className="text-xs text-ink/40 mt-1 italic">Coming soon</p>
+            )}
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function TrackBanner({
+  title,
+  pull,
+  items,
+  flip = false,
+}: {
+  title: string;
+  pull: string;
+  items: Item[];
+  flip?: boolean;
+}) {
+  return (
+    <section className="border-b border-ink/10 last:border-0">
+      <div
+        className={`max-w-6xl mx-auto px-6 py-14 grid lg:grid-cols-2 gap-12 items-start ${
+          flip ? "lg:[&>*:first-child]:order-last" : ""
+        }`}
+      >
+        <div>
+          <h2 className="font-serif text-3xl mb-5">{title}</h2>
+          <blockquote className="border-l-2 border-accent/40 pl-5 font-serif italic text-ink/70 leading-relaxed text-lg">
+            {pull}
+          </blockquote>
+        </div>
+        <TrackItems items={items} />
+      </div>
+    </section>
+  );
+}
+
+// ── Page ─────────────────────────────────────────────────────────────────────
+
 export default function Publications() {
   return (
-    <div className="max-w-5xl mx-auto px-6 py-16">
+    <>
       <PageHead
         title="Publications"
-        description="Sermons, worship resources, newsletters, and congregation materials from Hope and Truth Ministry — freely offered for the gathered and the wandering alike."
+        description="Find inspiration, gather resources, and discover how to build your own ministry or nonprofit — sermons, liturgy, stewardship tools, and purpose-driven development guides from Hope and Truth Ministry."
         path="/publications/"
       />
 
-      <p className="text-sm uppercase tracking-widest text-accent mb-4">
-        Publications &amp; Resources
-      </p>
-      <h1 className="font-serif text-5xl mb-4 leading-tight">
-        Words for the journey.
-      </h1>
-      <p className="text-lg text-ink/70 max-w-prose leading-relaxed mb-16">
-        Sermons and liturgical materials offered freely, with newsletters and
-        congregation resources on the way. All of it made to be used, shared,
-        and adapted.
-      </p>
-
-      <div className="grid sm:grid-cols-2 gap-6">
-        {/* Sermons */}
-        <Link
-          to="/sermons"
-          className="group block border border-ink/10 rounded-lg p-8 hover:border-accent/40 hover:bg-accent/5 transition-colors"
-        >
-          <p className="text-xs uppercase tracking-widest text-accent mb-3">Archive</p>
-          <h2 className="font-serif text-2xl mb-3 group-hover:text-accent">Sermons</h2>
-          <p className="text-ink/70 text-sm leading-relaxed">
-            Hundreds of sermons across the Revised Common Lectionary &mdash;
-            grouped by year, searchable by season and scripture.
-          </p>
-          <p className="mt-4 text-sm text-accent font-medium">Browse sermons &rarr;</p>
-        </Link>
-
-        {/* Worship Resources */}
-        <Link
-          to="/worship-resources"
-          className="group block border border-ink/10 rounded-lg p-8 hover:border-accent/40 hover:bg-accent/5 transition-colors"
-        >
-          <p className="text-xs uppercase tracking-widest text-accent mb-3">Liturgy</p>
-          <h2 className="font-serif text-2xl mb-3 group-hover:text-accent">Worship Resources</h2>
-          <p className="text-ink/70 text-sm leading-relaxed">
-            Service orders, Lessons &amp; Carols, pastoral prayers, and other
-            liturgical materials available for use and adaptation.
-          </p>
-          <p className="mt-4 text-sm text-accent font-medium">Browse resources &rarr;</p>
-        </Link>
-
-        {/* Newsletters — coming soon */}
-        <div className="border border-ink/10 rounded-lg p-8 opacity-70">
-          <p className="text-xs uppercase tracking-widest text-ink/50 mb-3">Coming soon</p>
-          <h2 className="font-serif text-2xl mb-3 text-ink/60">Newsletters</h2>
-          <p className="text-ink/60 text-sm leading-relaxed">
-            Periodic letters from this ministry to the gathered &mdash; seasonal
-            reflections, announcements, and notes from the community.
-          </p>
-          <p className="mt-4 text-sm text-ink/40 font-medium">Coming soon</p>
-        </div>
-
-        {/* Congregation Resources — coming soon */}
-        <div className="border border-ink/10 rounded-lg p-8 opacity-70">
-          <p className="text-xs uppercase tracking-widest text-ink/50 mb-3">Coming soon</p>
-          <h2 className="font-serif text-2xl mb-3 text-ink/60">Congregation Resources</h2>
-          <p className="text-ink/60 text-sm leading-relaxed">
-            Study guides, devotional materials, liturgical planning tools, and
-            other resources for congregations and small groups.
-          </p>
-          <p className="mt-4 text-sm text-ink/40 font-medium">Coming soon</p>
-        </div>
+      {/* Header */}
+      <div className="max-w-6xl mx-auto px-6 pt-16 pb-10 border-b border-ink/10">
+        <p className="text-sm uppercase tracking-widest text-accent mb-4">
+          Publications &amp; Resources
+        </p>
+        <h1 className="font-serif text-5xl mb-5 leading-tight">
+          Find inspiration. Gather resources.<br className="hidden sm:block" /> Build something.
+        </h1>
+        <p className="text-lg text-ink/70 max-w-prose leading-relaxed">
+          Hope &amp; Truth Ministry is a place to seek, to learn, and to discover how
+          to build something of your own &mdash; a congregation, a nonprofit, an
+          organization that is unmistakably yours.
+        </p>
       </div>
 
-      <div className="mt-16 pt-10 border-t border-ink/10">
-        <p className="text-ink/70 max-w-prose leading-relaxed">
-          Are you a minister, church, or ministry leader looking to grow your
-          congregation&apos;s resources?{" "}
-          <Link to="/ordination" className="text-accent underline">
-            Explore ordination and ministry resources
-          </Link>{" "}
-          or visit our{" "}
-          <Link to="/give" className="text-accent underline">
-            stewardship resources
-          </Link>{" "}
-          for tools to strengthen your ministry&apos;s financial foundation.
-        </p>
-        <p className="text-xs text-ink/50 mt-6">
+      {/* Track 1 — Inspiration */}
+      <TrackBanner
+        title="Inspiration"
+        pull="Before the sermon, before the service, before the words — there is silence. These materials help you find it."
+        items={INSPIRATION}
+      />
+
+      {/* Track 2 — Resources */}
+      <TrackBanner
+        title="Resources"
+        pull="Every ministry is built on what it gives away. These tools are here to be used, adapted, and passed forward."
+        items={RESOURCES}
+        flip
+      />
+
+      {/* Track 3 — Work Ideation */}
+      <TrackBanner
+        title="Work Ideation"
+        pull='"The journey of a thousand miles begins with a single step." — Lao Tzu'
+        items={IDEATION}
+      />
+
+      {/* Footer note */}
+      <div className="max-w-6xl mx-auto px-6 py-10">
+        <p className="text-xs text-ink/50">
           Content on this site is &copy; Tony E Hansen / Hope and Truth Ministry.
           Free to share with attribution.{" "}
-          <Link to="/terms" className="underline hover:text-ink/70">Terms of use &rarr;</Link>
+          <Link to="/terms" className="underline hover:text-ink/70">
+            Terms of use &rarr;
+          </Link>
         </p>
       </div>
-    </div>
+    </>
   );
 }

--- a/src/pages/Publications.tsx
+++ b/src/pages/Publications.tsx
@@ -6,7 +6,7 @@ import PageHead from "~/components/PageHead";
 const INSPIRATION = [
   {
     title: "Sermons",
-    desc: "Hundreds of sermons drawn from the Revised Common Lectionary — a year's worth of scripture, season by season.",
+    desc: "Reflections and sermons drawn from the Revised Common Lectionary - season by season",
     href: "/sermons",
     live: true,
     cta: "Browse the archive",
@@ -20,7 +20,7 @@ const INSPIRATION = [
   },
   {
     title: "Worship Resources",
-    desc: "Service orders, Lessons & Carols, pastoral prayers — materials that carry the season into the room.",
+    desc: "Service orders — materials that carry the season into the community.",
     href: "/worship-resources",
     live: true,
     cta: "Browse resources",
@@ -173,7 +173,7 @@ export default function Publications() {
     <>
       <PageHead
         title="Publications"
-        description="Find inspiration, gather resources, and discover how to build your own ministry or nonprofit — sermons, liturgy, stewardship tools, and purpose-driven development guides from Hope and Truth Ministry."
+        description="Find inspiration, gather resources, and discover a path to build your own ministry or nonprofit — sermons, liturgy, stewardship tools, and purpose-driven development guides from Hope and Truth Ministry."
         path="/publications/"
       />
 
@@ -182,27 +182,29 @@ export default function Publications() {
         <p className="text-sm uppercase tracking-widest text-accent mb-4">
           Publications &amp; Resources
         </p>
-        <h1 className="font-serif text-5xl mb-5 leading-tight">
-          Find inspiration. Gather resources.<br className="hidden sm:block" /> Build something.
+        <h1 className="font-serif text-4xl mb-5 leading-snug">
+          <span className="block">Find inspiration.</span>
+          <span className="block pl-6">Gather resources.</span>
+          <span className="block pl-12">Discover paths.</span>
         </h1>
         <p className="text-lg text-ink/70 max-w-prose leading-relaxed">
-          Hope &amp; Truth Ministry is a place to seek, to learn, and to discover how
-          to build something of your own &mdash; a congregation, a nonprofit, an
-          organization that is unmistakably yours.
+          Hope &amp; Truth Ministry is a place to seek, to learn, and to discover a path
+          to build something of your own &mdash; a congregation or a nonprofit
+          organization delivering purpose and services to the community.
         </p>
       </div>
 
       {/* Track 1 — Inspiration */}
       <TrackBanner
         title="Inspiration"
-        pull="Before the sermon, before the service, before the words — there is silence. These materials help you find it."
+        pull="Before the sermon, before the service, before the words — there is contemplation. These materials help you find inspiration."
         items={INSPIRATION}
       />
 
       {/* Track 2 — Resources */}
       <TrackBanner
         title="Resources"
-        pull="Every ministry is built on what it gives away. These tools are here to be used, adapted, and passed forward."
+        pull="Ministry is built on what it provides. These tools are here to be used and adapted to build your purpose."
         items={RESOURCES}
         flip
       />
@@ -218,7 +220,7 @@ export default function Publications() {
       <div className="max-w-6xl mx-auto px-6 py-10">
         <p className="text-xs text-ink/50">
           Content on this site is &copy; Tony E Hansen / Hope and Truth Ministry.
-          Free to share with attribution.{" "}
+          Welcome to share per the {" "}
           <Link to="/terms" className="underline hover:text-ink/70">
             Terms of use &rarr;
           </Link>


### PR DESCRIPTION
## Summary

- **Interfaith mandala** — SVG wheel of world religions (Christianity, Judaism, Islam, Hinduism, Buddhism, Sikhism, Taoism, Bahá'í) on the home page and as the site favicon
- **Publications hub rebuilt** — three-track layout (Inspiration / Resources / Work Ideation) replacing the old 2×2 card grid; frames H&T as a launchpad for ministry and nonprofit builders
- **About page mission** — clarified as "spiritual home and launchpad"; new Mission section; "Find your way in" replaces the awkward "How this ministry works"
- **h1 normalization** — all page headings standardized to `text-4xl`; Publications heading uses a stair-step layout; Home hero kept at `sm:text-5xl`

## Test plan

- [ ] Home page — interfaith wheel visible, hero photo intact
- [ ] `/publications` — three tracks render, stair-step heading correct
- [ ] `/about` — mission statement clear, "Find your way in" section flows
- [ ] All pages — h1 consistent size
- [ ] Browser tab — SVG favicon visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)