### PR TITLE
Analytics, content fixes, Publications & About updates

### DIFF
--- a/scripts/analytics.sh
+++ b/scripts/analytics.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# Query CloudFront page view analytics via AWS Athena.
+#
+# CloudFront logs land in s3://hopeandtruthministry-logs/cloudfront/ (90-day retention).
+# Athena queries them without downloading anything — results print to the terminal.
+#
+# Usage:
+#   ./scripts/analytics.sh                  # top 25 pages, last 30 days
+#   ./scripts/analytics.sh --days 7         # last 7 days
+#   ./scripts/analytics.sh --days 90        # full retention window
+#   ./scripts/analytics.sh --referrers      # top referrers instead of pages
+#   ./scripts/analytics.sh --daily          # daily totals (trend view)
+#
+# Requirements: aws-cli v2 authenticated, region us-west-2.
+
+set -euo pipefail
+
+WORKGROUP="hopeandtruth-analytics"
+REGION="us-west-2"
+DAYS=30
+MODE="pages"
+
+for arg in "$@"; do
+  case "$arg" in
+    --days)    shift; DAYS="$1" ;;
+    --referrers) MODE="referrers" ;;
+    --daily)   MODE="daily" ;;
+  esac
+done
+
+run_query() {
+  local sql="$1"
+  local exec_id
+  exec_id=$(aws athena start-query-execution \
+    --query-string "$sql" \
+    --work-group "$WORKGROUP" \
+    --region "$REGION" \
+    --query 'QueryExecutionId' --output text)
+
+  # Wait for completion
+  local state="RUNNING"
+  while [[ "$state" == "RUNNING" || "$state" == "QUEUED" ]]; do
+    sleep 2
+    state=$(aws athena get-query-execution \
+      --query-execution-id "$exec_id" \
+      --region "$REGION" \
+      --query 'QueryExecution.Status.State' --output text)
+  done
+
+  if [[ "$state" != "SUCCEEDED" ]]; then
+    local reason
+    reason=$(aws athena get-query-execution \
+      --query-execution-id "$exec_id" \
+      --region "$REGION" \
+      --query 'QueryExecution.Status.StateChangeReason' --output text)
+    echo "Query failed: $reason" >&2
+    exit 1
+  fi
+
+  aws athena get-query-results \
+    --query-execution-id "$exec_id" \
+    --region "$REGION" \
+    --query 'ResultSet.Rows[*].Data[*].VarCharValue' \
+    --output table
+}
+
+case "$MODE" in
+  pages)
+    echo "=== Top pages — last ${DAYS} days ==="
+    run_query "
+      SELECT uri, COUNT(*) AS views
+      FROM cloudfront_logs.access_logs
+      WHERE status = 200
+        AND method = 'GET'
+        AND uri NOT LIKE '%.js'
+        AND uri NOT LIKE '%.css'
+        AND uri NOT LIKE '%.jpg'
+        AND uri NOT LIKE '%.png'
+        AND uri NOT LIKE '%.svg'
+        AND uri NOT LIKE '%.ico'
+        AND uri NOT LIKE '%.map'
+        AND uri NOT LIKE '/.vite/%'
+        AND log_date >= DATE_ADD('day', -${DAYS}, CURRENT_DATE)
+      GROUP BY uri
+      ORDER BY views DESC
+      LIMIT 25
+    "
+    ;;
+
+  referrers)
+    echo "=== Top referrers — last ${DAYS} days ==="
+    run_query "
+      SELECT referrer, COUNT(*) AS visits
+      FROM cloudfront_logs.access_logs
+      WHERE status = 200
+        AND referrer != '-'
+        AND referrer NOT LIKE '%hopeandtruthministry.com%'
+        AND log_date >= DATE_ADD('day', -${DAYS}, CURRENT_DATE)
+      GROUP BY referrer
+      ORDER BY visits DESC
+      LIMIT 20
+    "
+    ;;
+
+  daily)
+    echo "=== Daily page views — last ${DAYS} days ==="
+    run_query "
+      SELECT log_date, COUNT(*) AS views
+      FROM cloudfront_logs.access_logs
+      WHERE status = 200
+        AND method = 'GET'
+        AND uri NOT LIKE '%.js'
+        AND uri NOT LIKE '%.css'
+        AND uri NOT LIKE '%.jpg'
+        AND uri NOT LIKE '%.png'
+        AND uri NOT LIKE '%.svg'
+        AND log_date >= DATE_ADD('day', -${DAYS}, CURRENT_DATE)
+      GROUP BY log_date
+      ORDER BY log_date DESC
+    "
+    ;;
+esac

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -35,8 +35,8 @@ export default function Layout() {
             <div>
               <p className="font-medium text-ink/80 mb-2">Hope &amp; Truth Ministry</p>
               <p>
-                A ministry without walls. Open and affirming; wandering
-                and welcomed.
+                A ministry without walls. Interfaith and welcoming;
+                for the wandering and the seeking.
               </p>
             </div>
             <div>

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -33,7 +33,7 @@ export default function About() {
           organization rooted in your calling.
         </p>
         <p>
-          It is open and affirming, interfaith and without walls. For the
+          It is interfaith and without walls. For the
           wandering, the doubting, the questioning, the hurting, and the
           hopeful. For those whose church is online. For those finding their
           way back. For those still seeking. And for those who are ready to
@@ -62,8 +62,9 @@ export default function About() {
       <div className="space-y-4 text-ink/80 max-w-prose leading-relaxed">
         <p>
           Hope and Truth Ministry exists to provide a truly welcoming,
-          open and affirming community to all people seeking meaning, purpose,
+          open and interfaith community to all people seeking meaning, purpose,
           and connection &mdash; no matter where they are on life&apos;s journey.
+          We work to end all bigotry and racism while providing a safe space for contemplation.
         </p>
         <p>
           Beyond the congregation, this ministry serves as a resource for

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -10,7 +10,7 @@ export default function Home() {
     <>
       <PageHead
         title="Hope and Truth Ministry — a ministry without walls"
-        description="A welcoming, open-and-affirming ministry without walls — sermons, reflections, and worship resources rooted in the Revised Common Lectionary, for the wandering, the doubting, the hurting, and the hopeful."
+        description="A welcoming, interfaith ministry without walls — sermons, reflections, and worship resources rooted in the Revised Common Lectionary, for the wandering, the doubting, the hurting, and the hopeful."
         path="/"
         isHome
       />


### PR DESCRIPTION
## Summary

- **CloudFront analytics via Athena** — `hopeandtruthministry-logs` S3 bucket (90-day retention), logging enabled on both distributions, Athena workgroup + table configured. `scripts/analytics.sh` queries top pages, referrers, or daily totals with one command.
- **Remove 'open and affirming'** — UCC coalition term removed from Layout footer, Home meta description, and About page. Replaced with 'interfaith and welcoming.'
- **Publications hub** — three-track layout (Inspiration / Resources / Work Ideation), stair-step heading at text-4xl.
- **About mission** — clarified as spiritual home and launchpad for builders; 'Find your way in' section.
- **h1 normalization** — all pages standardized to text-4xl.
- **Interfaith wheel** — SVG mandala on home page and as favicon.

## Test plan

- [ ] `./scripts/analytics.sh` — runs without error (logs may be sparse for first day)
- [ ] No 'open and affirming' visible anywhere on site
- [ ] `/publications` — three tracks, stair-step heading
- [ ] `/about` — mission statement clear
- [ ] All page h1s consistent size

🤖 Generated with [Claude Code](https://claude.com/claude-code)